### PR TITLE
Always use `/usr/bin/python`

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -138,7 +138,7 @@ rm -rf "`realpath "$1" | sed 's/\.ipsw$//'`"
 killall iTunes iTunesHelper >/dev/null 2>&1 || true
 killall -STOP AMPDeviceDiscoveryAgent >/dev/null 2>&1 || true
 cd tools/ipwndfu
-arch -x86_64 python ./ipwndfu -p
+arch -x86_64 /usr/bin/python ./ipwndfu -p
 cd ../..
 echo
 echo 'IMPORTANT: an "FDR" error is normal, ignore it'


### PR DESCRIPTION
Some users may have the default `python` command in their `PATH` mapped to a Python 3.x executable by default (as 2.x is now EOL).
However, it appears that Python 2.x is required by the scripts, so this enforces that the system Python (which is 2.x) is always used, which is no longer dependant on the user's `PATH`.